### PR TITLE
Responsive

### DIFF
--- a/src/components/sys-paragraph-1.vue
+++ b/src/components/sys-paragraph-1.vue
@@ -27,7 +27,7 @@ export default {
 <style module>
   .paragraph1 {
     font-family: var(--font-family-sans);
-    font-size: 1rem;
+    font-size: 1.2rem;
     font-smooth: auto;
     hyphens: none;
     text-rendering: optimizeLegibility;
@@ -37,13 +37,13 @@ export default {
 
   @media (min-width: 600px) {
     .paragraph1 {
-      font-size: 1.225rem;
+      font-size: 1.25rem;
     }
   }
 
   @media (min-width: 1280px) {
     .paragraph1 {
-      font-size: 1.375rem;
+      font-size: 1.3rem;
     }
   }
 </style>

--- a/src/components/sys-paragraph-2.vue
+++ b/src/components/sys-paragraph-2.vue
@@ -27,7 +27,7 @@ export default {
 <style module>
   .paragraph2 {
     font-family: var(--font-family-sans);
-    font-size: 1.22rem;
+    font-size: 1.3rem;
     font-smooth: auto;
     hyphens: none;
     text-rendering: optimizeLegibility;
@@ -37,13 +37,13 @@ export default {
 
   @media (min-width: 600px) {
     .paragraph2 {
-      font-size: 1.5rem;
+      font-size: 1.4rem;
     }
   }
 
   @media (min-width: 1280px) {
     .paragraph2 {
-      font-size: 1.67rem;
+      font-size: 1.5rem;
     }
   }
 </style>

--- a/src/components/sys-subheader-2.vue
+++ b/src/components/sys-subheader-2.vue
@@ -27,7 +27,7 @@ export default {
 <style module>
   .subheader2 {
     font-family: var(--font-family-slab);
-    font-size: 1.4rem;
+    font-size: 1.5rem;
     font-smooth: auto;
     font-weight: 500;
     line-height: calc(var(--line-height) * 0.8333);

--- a/src/components/sys-subheader-5.vue
+++ b/src/components/sys-subheader-5.vue
@@ -27,23 +27,23 @@ export default {
 <style module>
   .subheader5 {
     font-family: var(--font-family-sans);
-    font-size: 1.2rem;
+    font-size: 1.5rem;
     font-smooth: auto;
     font-style: normal;
-    font-weight: 500;
+    font-weight: 600;
     line-height: calc(var(--line-height) * 0.8333);
     text-rendering: optimizeLegibility;
   }
 
   @media (min-width: 600px) {
     .subheader5 {
-      font-size: 1.375rem;
+      font-size: 1.6rem;
     }
   }
 
   @media (min-width: 1280px) {
     .subheader5 {
-      font-size: 1.6rem;
+      font-size: 1.8rem;
     }
   }
 </style>

--- a/src/tokens/font.stories.mdx
+++ b/src/tokens/font.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
 
+import * as components from '../components'
 import * as tokens from './index.module.js'
 
 <Meta title="Documentation|Font" />
@@ -33,24 +34,35 @@ export default {
 
 ## Examples
 
-<Preview>
-  <Story id="components-headers--sys-header-1" height="140px" />
-  <Story id="components-headers--sys-header-2" height="140px" />
-  <Story id="components-headers--sys-header-3" height="140px" />
-  <Story id="components-headers--sys-header-4" height="140px" />
-  <Story id="components-headers--sys-header-5" height="140px" />
-  <Story id="components-headers--sys-header-6" height="140px" />
-</Preview>
+You can [open the font examples in another tab](/iframe.html?id=documentation-font--font-examples)
+to get a better idea of breakpoints and how they change size depending on the
+viewport.
 
-<Preview>
-  <Story id="components-subheaders--sys-subheader-1" height="100px" />
-  <Story id="components-subheaders--sys-subheader-2" height="100px" />
-  <Story id="components-subheaders--sys-subheader-3" height="100px" />
-  <Story id="components-subheaders--sys-subheader-4" height="140px" />
-  <Story id="components-subheaders--sys-subheader-5" height="140px" />
-</Preview>
-
-<Preview>
-  <Story id="components-paragraphs--sys-paragraph-1" height="100px" />
-  <Story id="components-paragraphs--sys-paragraph-2" height="100px" />
-</Preview>
+<Story name="font-examples">
+  {{
+    components: components,
+    template: `
+      <div style="display:flex;flex-wrap:wrap;">
+        <div style="margin:2rem;">
+          <sys-header-1>Header 1</sys-header-1>
+          <sys-header-2>Header 2</sys-header-2>
+          <sys-header-3>Header 3</sys-header-3>
+          <sys-header-4>Header 4</sys-header-4>
+          <sys-header-5>Header 5</sys-header-5>
+          <sys-header-6>Header 6</sys-header-6>
+        </div>
+        <div style="margin:2rem;">
+          <sys-subheader-1>Subheader 1</sys-subheader-1>
+          <sys-subheader-2>Subheader 2</sys-subheader-2>
+          <sys-subheader-3>Subheader 3</sys-subheader-3>
+          <sys-subheader-4>Subheader 4</sys-subheader-4>
+          <sys-subheader-5>Subheader 5</sys-subheader-5>
+        </div>
+        <div style="margin:2rem;">
+          <sys-paragraph-1>Paragraph 1</sys-paragraph-1>
+          <sys-paragraph-2>Paragraph 2</sys-paragraph-2>
+        </div>
+      </div>
+    `
+  }}
+</Story>


### PR DESCRIPTION
- Updates paragraph styles to grow less on desktop sizes (it was getting larger than subheader 5)
- Updates subheaders to all have the same size and scaling. This will probably change in the future, but works now.
- Adds a better doc page to test font responsiveness

Made to match the fonts a bit more in the account mockups
![image](https://user-images.githubusercontent.com/3385679/74375756-25a58f00-4d9e-11ea-8835-fff8787259f6.png)
